### PR TITLE
Add SQLite icon support

### DIFF
--- a/src/utils/languages.ts
+++ b/src/utils/languages.ts
@@ -74,6 +74,10 @@ export const languages: Record<string, Language> = {
     className: "!bg-[#f6ece1]",
     iconName: "mysql",
   },
+  sqlite: {
+    name: "SQLite",
+    iconName: "sqlite",
+  },
   wordpress: {
     name: "Wordpress",
     iconName: "wordpress",


### PR DESCRIPTION
## Summary
- update languages dictionary with missing SQLite entry

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*